### PR TITLE
Anpassung der Klarnamenerkennung an neue Anforderungen

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-from nlpProcess import nlpProcess
-import importJSON
 import requests
 import folium
 from pprint import pprint
@@ -16,6 +14,7 @@ nlpProc = nlpProcess()
 input_data = importJSON.JSONReader("C:/Users/mhammed/Desktop/comments_export2.json")
 
 
+'''
 # Compute sentiment scores
 for id, comment in input.items():
     scores = nlpProc.analyzeSentiments(comment)
@@ -41,7 +40,7 @@ filtered = nlpProc.removeStopwords(list(input.values()))
 # Find entities in each comment.
 entities = nlpProc.findEntities(input)
 print(entities)
-
+'''
 # Remove real names in comments.
 privacy = nlpProc.filterNames(input)
 print(privacy)

--- a/nlpProcess.py
+++ b/nlpProcess.py
@@ -125,16 +125,23 @@ class nlpProcess(object):
         Returns
         -----------
         filtered_dict : dict
-            dictionary containing original comments without real names
+            dictionary containing only comments containing names
+            format: {comment_id {comment, name}}
         '''
         filtered_dict = {}
         for id, comment in comments_input.items():
-            doc = self.nlp(comment)
-            filteredComment = comment
+            doc = self.nlp(comment['text'])
+            filteredComment = comment['text']
+            names = []
             for ent in doc.ents:
                 if ent.label_ == 'PER':
+                    names.append(ent.text)
                     filteredComment = filteredComment.replace(ent.text, "<Klarname entfernt>")
-            filtered_dict[id] = filteredComment
+            if names:
+                filtered_dict[id] = {
+                    'comment': filteredComment,
+                    'names': names
+                }
 
         return filtered_dict
     


### PR DESCRIPTION
Die Klarnamenerkennung wurde angepasst, sodass die Methode FilterNames alle Kommentare zurückgibt, in denen mit der NER von Spacy Personen erkannt werden. Es werden die IDs, der Kommentartext sowie der erkannte Name zurückgegeben.